### PR TITLE
Removed extra space between emoji and message

### DIFF
--- a/bin/lib.js
+++ b/bin/lib.js
@@ -65,7 +65,7 @@ function initProject(gitHookPath) {
 
 function prependMessage(getMessage, putMessage) {
   return filepath => message => getMessage(filepath)
-    .then(fileContent => `${message}  ${fileContent}`)
+    .then(fileContent => `${message} ${fileContent}`)
     .then(fileContent => putMessage(filepath, fileContent));
 }
 


### PR DESCRIPTION
Currently the hook will add 2 spaces between the gitmoji and the message. I removed one of the spaces for a cleaner commit message.